### PR TITLE
Replace toml with Standard Library tomllib

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/armaqdl/config.py
+++ b/armaqdl/config.py
@@ -3,8 +3,6 @@ import shutil
 import tomllib
 from pathlib import Path
 
-from platformdirs import PlatformDirs
-
 from .const import CONFIG_DIR, SETTINGS_FILE
 
 DIST_CONFIG_DIR = Path(__file__).parent / "config"

--- a/armaqdl/config.py
+++ b/armaqdl/config.py
@@ -24,8 +24,9 @@ def generate():
 
 def load(folder):
     try:
-        settings = tomllib.loads(folder / SETTINGS_FILE)
-    except tomllib.TomlDecodeError as e:
+        with open(folder / SETTINGS_FILE, "rb") as f:
+            settings = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
         print(f"Error! Invalid settings file or format!\n{e}")
         return None
 

--- a/armaqdl/config.py
+++ b/armaqdl/config.py
@@ -1,8 +1,8 @@
 import os
 import shutil
+import tomllib
 from pathlib import Path
 
-import toml
 from platformdirs import PlatformDirs
 
 CONFIG_DIR = Path(PlatformDirs("ArmaQDL", False, roaming=True).user_config_dir)
@@ -24,12 +24,9 @@ def generate():
 
 def load(folder):
     try:
-        settings = toml.load(folder / SETTINGS_FILE)
-    except TypeError as e:
-        print(f"Error! Invalid settings file!\n{e}")
-        return None
-    except toml.TomlDecodeError as e:
-        print(f"Error! Invalid settings format!\n{e}")
+        settings = tomllib.loads(folder / SETTINGS_FILE)
+    except tomllib.TomlDecodeError as e:
+        print(f"Error! Invalid settings file or format!\n{e}")
         return None
 
     return settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,10 @@ authors = [
 description = "Python program for quick launching various mod development configurations for Arma through a simple CLI."
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.7"
+requires-python = ">=3.11"
 classifiers = [
   "Environment :: Console",
   "Intended Audience :: Developers",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "License :: OSI Approved :: MIT License",
   "Operating System :: Microsoft :: Windows",
@@ -25,7 +21,6 @@ classifiers = [
 ]
 dependencies = [
   "platformdirs",
-  "toml",
 ]
 dynamic = [
   "version",
@@ -69,7 +64,7 @@ dependencies = [
 full = "pytest {args:tests}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311"]
+python = ["311"]
 
 [tool.hatch.envs.lint]
 detached = true


### PR DESCRIPTION
- **Bumps minimal Python to 3.11**
- Close #3 

Will not merge until 3.11 becomes more mainstream and probably not even then for some time. There are currently no issues with the `toml` library.